### PR TITLE
Basic認証の導入

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,13 @@
 class ApplicationController < ActionController::Base
+  before_action :basic_auth
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   private
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == 'saotome' && password == '1234'
+    end
+  end
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up,

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   private
   def basic_auth
     authenticate_or_request_with_http_basic do |username, password|
-      username == 'saotome' && password == '1234'
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
     end
   end
 


### PR DESCRIPTION
## what
・Basic認証を導入するため、application_controllerで設定をした。
・使用メソッド　authentic_request_with_http_basic
・最終的なユーザー名とパスワードは環境変数に格納した。

## why
・限定したユーザーのみ使用可能にするため